### PR TITLE
added statically linked leaderboard-tinytest package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
-packages/*
+packages/jasmine-unit		
+packages/mirror			
+packages/moment			
+packages/velocity
+packages/mocha-web-velocity	
+packages/package-stubber		
+packages/velocity-html-reporter
+
 tests/a1-package-stubs.js
 smart.lock

--- a/packages/.gitignore
+++ b/packages/.gitignore
@@ -1,0 +1,7 @@
+/velocity
+/mocha-web-velocity
+/jasmine-unit
+/velocity-html-reporter
+/moment
+/mirror
+/package-stubber

--- a/packages/leaderboard-tinytests/README.md
+++ b/packages/leaderboard-tinytests/README.md
@@ -1,0 +1,32 @@
+leaderboard-tinytests
+=====================
+
+Unit tests for the Leaderboard example using Tinytest.  
+
+
+#### Installation  
+
+````sh
+// grab a copy of meteor 
+git clone http://github.com/meteor/meteor.git
+
+// so you can fuss with the leaderboard example
+cd meteor/examples/leaderboard/packages
+
+// install the tinytests
+git clone http://github.com/awatson1978/leaderboard-tinytests.git
+
+// make sure the tiny test package is installed
+cd ..
+meteor add tinytests
+
+// and run them
+meteor test-packages leaderboard-tinytests
+````
+
+Check ``http://localhost:3000`` to see them run.
+
+
+#### Notes  
+
+The ``fireEvent`` stub isn't mocked up to anything, which is why the last test is failing.

--- a/packages/leaderboard-tinytests/leaderboard-tests.js
+++ b/packages/leaderboard-tinytests/leaderboard-tests.js
@@ -1,0 +1,77 @@
+
+
+Tinytest.add('Template.leaderboard.players()', function (test) {
+
+  var someLocalCollectionCursor = {};
+  Players.find = function (selector, options) {
+      test.equal(options.sort.score, -1);
+      test.equal(options.sort.name, 1);
+      // expect(options.sort.score).toBe(-1);
+      // expect(options.sort.name).toBe(1);
+      return someLocalCollectionCursor;
+  };
+
+  test.equal(Template.leaderboard.players(), someLocalCollectionCursor);
+  //expect(Template.leaderboard.players()).toBe(someLocalCollectionCursor);
+});
+
+
+Tinytest.add('Template.leaderboard.selected_name()', function (test) {
+
+  // returns player when player is found and has a name
+  Players.findOne = function () {
+      return {name: 'Tom'};
+  };
+  test.equal(Template.leaderboard.selected_name(), "Tom");
+
+
+  // returns undefined when player.name isn't present
+  Players.findOne = function () {
+      return {};
+  };
+  test.equal(Template.leaderboard.selected_name(), undefined);
+
+  // returns undefined when player doesn't exist
+  Players.findOne = function () {
+      return undefined;
+  };
+  test.equal(Template.leaderboard.selected_name(), undefined);
+
+});
+
+
+Tinytest.add('Template.player.selected()', function (test) {
+
+  // returns selected when the selected player in the session matches player in the current template
+  Template.player._id = 1234;
+  Session.set('selected_player', 1234);
+  test.equal(Template.player.selected(), "selected");
+
+
+  // returns empty string when the selected player in the session doesn't matches player in the current template
+  Template.player._id = 4321;
+  Session.set('selected_player', 1234);
+  test.equal(Template.player.selected(), "");
+});
+
+
+Tinytest.add('Template.leaderboard [click input.inc] event', function (test) {
+
+  //updates the player score by 5 when input.inc is clicked
+  Session.set('selected_player', 1234);
+  Players.update = function (selector, options) {
+      test.equal(selector, 1234);
+      test.equal(options.$inc.score, 5);
+  };
+  Template.leaderboard.fireEvent('click input.inc');
+});
+
+
+Tinytest.add('Template.player [click] event', function (test) {
+
+  //clicking a player sets them to the selected player in the session
+  Template.player.addContextAttribute('_id', 888);
+  Template.player.fireEvent('click');
+  test.equal(Session.get("selected_player"), 888);
+
+});

--- a/packages/leaderboard-tinytests/package.js
+++ b/packages/leaderboard-tinytests/package.js
@@ -1,0 +1,21 @@
+Package.describe({
+  summary: "Provides unit tests for leaderboard application.",
+  internal: true
+});
+
+
+Package.on_test(function (api) {
+
+  api.use('tinytest');
+  api.use(["spacebars", "tinytest", "test-helpers"]);
+  api.use("templating", "client");
+
+  api.add_files('test-stubs.js', 'client');
+  api.add_files('../../leaderboard.js', 'client');
+
+  //api.use('session', 'client');
+  //api.use('session-extended-api');
+  //api.use('deps');
+  //api.use('mongo-livedata');
+  api.add_files('leaderboard-tests.js', 'client');
+});

--- a/packages/leaderboard-tinytests/smart.json
+++ b/packages/leaderboard-tinytests/smart.json
@@ -1,0 +1,8 @@
+{
+    "name": "leaderboard-tinytests",
+    "description": "Provides unit tests for leaderboard application.",
+    "homepage": "https://github.com/awatson1978/leaderboard-tinytests",
+    "author": "Abigail Watson  (http://www.pentasyllabic.com)",
+    "version": "0.1.0",
+    "git": "https://github.com/awatson1978/leaderboard-tinytests.git"
+}

--- a/packages/leaderboard-tinytests/test-stubs.js
+++ b/packages/leaderboard-tinytests/test-stubs.js
@@ -1,0 +1,13 @@
+Template = {
+  leaderboard: {
+    events: function(){ return; },
+    fireEvent: function(){ return; }
+  },
+  player: {
+    events: function(){ return; },
+    addContextAttribute: function(){ return; },
+    fireEvent: function(){ return; }
+  }
+};
+
+Players = {};


### PR DESCRIPTION
Not 100% velocity, but if the overall intent is to provide integrated Meteor testing solutions, it's probably a good idea to have an example of how to do unit testing on the Leaderboard example with the built in Tinytest framework.
